### PR TITLE
Add camera and microphone entitlements

### DIFF
--- a/BolWallet/Platforms/MacCatalyst/Entitlements.plist
+++ b/BolWallet/Platforms/MacCatalyst/Entitlements.plist
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is required so the necessary hardened runtime exclusions are allowed and to fix the related permissions requests to work properly in release configuration.