### PR TITLE
Remove CSS to uppercase inputs, fixes #93

### DIFF
--- a/BolWallet/Pages/CreateCodenameIndividualPage.razor
+++ b/BolWallet/Pages/CreateCodenameIndividualPage.razor
@@ -90,10 +90,6 @@
     </MudForm>
 </div>
 <style>
-    input.mud-input-slot {
-        text-transform: uppercase;
-    }
-
     .text-center {
         text-align: center;
     }


### PR DESCRIPTION
This will preserve the codename casing in the related field. The rest of the inputs will still show values in upper case, since they are already using it from a previous step of the workflow.