### PR TITLE
Fix Blank Screen Issue with PasswordPopup on Android Devices - issue [https://github.com/bol-project/bol-wallet/issues/102]

### DIFF
--- a/BolWallet/ViewModels/PasswordPopup.cs
+++ b/BolWallet/ViewModels/PasswordPopup.cs
@@ -87,7 +87,7 @@ public sealed class PasswordPopup : Popup
             HorizontalOptions = LayoutOptions.Fill
         };
 
-        var mockFrame = new BoxView
+        var boxView = new BoxView
         {
             CornerRadius = 20,
             BackgroundColor = Colors.White,
@@ -104,7 +104,7 @@ public sealed class PasswordPopup : Popup
             HeightRequest = 400,
             Children =
         {
-            mockFrame,
+            boxView,
             new VerticalStackLayout
             {
                 Children = { titleLabel, stackLayout },


### PR DESCRIPTION
- Update password popup to use BoxView instead of Frame
![Screenshot_1712223298](https://github.com/bol-project/bol-wallet/assets/56189403/25bb63f9-2613-4991-8e1e-c7a24996a30e)
