### PR TITLE
Fix issue where country selection order was affected by going back and forth 

### DIFF
--- a/BolWallet/ViewModels/CitizenshipViewModel.cs
+++ b/BolWallet/ViewModels/CitizenshipViewModel.cs
@@ -127,9 +127,22 @@ public partial class CitizenshipViewModel : BaseViewModel
                     SurName = string.Empty,
                     Nin = string.Empty
                 });
-
-            UserData.Citizenships = savedCountriesToKeep.Concat(newCountries).ToList();
-            UserData.EncryptedCitizenshipForms = savedCitizenships.Concat(newCitizenships).ToList();
+            
+            var selectionOrder = SelectedCountries
+                .Select((country, index) => (c: country, i: index))
+                .ToDictionary(c => c.c, c => c.i);
+            
+            // We want the countries to be in the same order as the user selected them
+            // Otherwise, if the order randomly changes, EDI creation will not be deterministic.
+            UserData.Citizenships = savedCountriesToKeep
+                .Concat(newCountries)
+                .OrderBy(c => selectionOrder[c.Name])
+                .ToList();
+            
+            UserData.EncryptedCitizenshipForms = savedCitizenships
+                .Concat(newCitizenships)
+                .OrderBy(c => selectionOrder[c.CountryName])
+                .ToList();
 
             await _secureRepository.SetAsync("userdata", UserData);
         }


### PR DESCRIPTION
When **adding and removing countries** on the Citizenships page or after submitting the Form and going back to change it, there were cases where **the order of the selected countries was changed after submitting the form**.

Now the list of countries and citizenship forms are always ordered by the selection order.

They will always appear in that order when moving to the next page and provide certificates for each country. 