### PR TITLE
Disable wallet creations on iOS

### DIFF
--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>BolWallet</RootNamespace>
     <UseMaui>true</UseMaui>
-    <MauiVersion>8.0.82</MauiVersion>
+    <MauiVersion>8.0.90</MauiVersion>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
 

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -259,7 +259,9 @@
     <EmbeddedResource Include="appsettings.json" />
     <Content Remove="appsettings.Development.json" />
     <EmbeddedResource Include="appsettings.Development.json" />
+    <Content Remove="Resources\Content\country_code.json" />
     <EmbeddedResource Include="Resources\Content\country_code.json" />
+    <Content Remove="Resources\Content\nin.json" />
     <EmbeddedResource Include="Resources\Content\nin.json" />
     <Content Remove="TestAccount.json" />
   </ItemGroup>

--- a/src/BolWallet/Views/MainPage.xaml
+++ b/src/BolWallet/Views/MainPage.xaml
@@ -38,7 +38,8 @@
                 FontAttributes="Bold"
                 HorizontalOptions="Center"
                 WidthRequest="200"
-                Text="New Individual Wallet" />
+                Text="New Individual Wallet" 
+                IsVisible="{OnPlatform iOS=false, Default=true}" />
 
             <Button
                 Grid.Row="3"
@@ -46,7 +47,8 @@
                 FontAttributes="Bold"
                 HorizontalOptions="Center"
                 WidthRequest="200"
-                Text="New Company Wallet" />
+                Text="New Company Wallet" 
+                IsVisible="{OnPlatform iOS=false, Default=true}" />
             <Button
              Grid.Row="4"
              Command="{Binding ImportYourWalletCommand}"


### PR DESCRIPTION
Until all Apple's requirements for the app to be accepted on AppStore are met, the buttons to register new accounts are made invisible on iOS, so new wallets cannot be created from the iOS app.