### PR TITLE
Fix issue about "no wallet" in whitelist page after a new wallet was created

### DIFF
--- a/src/BolWallet/Constants.cs
+++ b/src/BolWallet/Constants.cs
@@ -16,6 +16,7 @@ internal class Constants
     // Static messages to re-use
     public static readonly TargetNetworkChangedMessage TargetNetworkChangedMessage = new();
     public static readonly WalletClosedMessage WalletClosedMessage = new();
+    public static readonly WalletCreatedMessage WalletCreatedMessage = new();
     
     public static readonly JsonSerializerOptions WalletJsonSerializerDefaultOptions = new()
     {

--- a/src/BolWallet/Models/Messages/WalletCreatedMessage.cs
+++ b/src/BolWallet/Models/Messages/WalletCreatedMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace BolWallet.Models.Messages;
+
+public record WalletCreatedMessage;

--- a/src/BolWallet/Services/BolServiceFactory.cs
+++ b/src/BolWallet/Services/BolServiceFactory.cs
@@ -14,12 +14,13 @@ public class BolServiceFactory : IRecipient<WalletClosedMessage>, IRecipient<Wal
 
     public BolServiceFactory(
         IServiceScopeFactory serviceScopeFactory,
+        IMessenger messenger,
         ILogger<BolServiceFactory> logger)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
-        WeakReferenceMessenger.Default.Register<WalletClosedMessage>(this);
-        WeakReferenceMessenger.Default.Register<WalletCreatedMessage>(this);
+        messenger.Register<WalletClosedMessage>(this);
+        messenger.Register<WalletCreatedMessage>(this);
     }
 
     public IBolService Create()

--- a/src/BolWallet/Services/BolServiceFactory.cs
+++ b/src/BolWallet/Services/BolServiceFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace BolWallet.Services;
 
-public class BolServiceFactory : IRecipient<WalletClosedMessage>
+public class BolServiceFactory : IRecipient<WalletClosedMessage>, IRecipient<WalletCreatedMessage>
 {
     private IServiceScope _serviceScope;
     private readonly IServiceScopeFactory _serviceScopeFactory;
@@ -18,7 +18,8 @@ public class BolServiceFactory : IRecipient<WalletClosedMessage>
     {
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
-        WeakReferenceMessenger.Default.Register(this);
+        WeakReferenceMessenger.Default.Register<WalletClosedMessage>(this);
+        WeakReferenceMessenger.Default.Register<WalletCreatedMessage>(this);
     }
 
     public IBolService Create()
@@ -30,6 +31,13 @@ public class BolServiceFactory : IRecipient<WalletClosedMessage>
     public void Receive(WalletClosedMessage message)
     {
         _logger.LogInformation("Received {Message}, disposing BOL services...", message.GetType().Name);
+        _serviceScope?.Dispose();
+        _serviceScope = null;
+    }
+    
+    public void Receive(WalletCreatedMessage message)
+    {
+        _logger.LogInformation("Received {Message}, disposing BOL services so new instances get access to new wallet...", message.GetType().Name);
         _serviceScope?.Dispose();
         _serviceScope = null;
     }

--- a/src/BolWallet/ViewModels/GenerateWalletWithPasswordViewModel.cs
+++ b/src/BolWallet/ViewModels/GenerateWalletWithPasswordViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using Bol.Core.Abstractions;
-using Bol.Cryptography;
 using CommunityToolkit.Maui.Alerts;
-using CommunityToolkit.Maui.Storage;
-using System.Text;
+using CommunityToolkit.Mvvm.Messaging;
 
 namespace BolWallet.ViewModels;
 
@@ -12,19 +10,22 @@ public partial class GenerateWalletWithPasswordViewModel : BaseViewModel
     private readonly ISecureRepository _secureRepository;
     private readonly IFileDownloadService _fileDownloadService;
     private readonly IDeviceDisplay _deviceDisplay;
+    private readonly IMessenger _messenger;
 
     public GenerateWalletWithPasswordViewModel(
         INavigationService navigationService,
         IWalletService walletService,
         ISecureRepository secureRepository,
         IFileDownloadService fileDownloadService,
-        IDeviceDisplay deviceDisplay)
+        IDeviceDisplay deviceDisplay,
+        IMessenger messenger)
         : base(navigationService)
     {
         _walletService = walletService;
         _secureRepository = secureRepository;
         _fileDownloadService = fileDownloadService;
         _deviceDisplay = deviceDisplay;
+        _messenger = messenger;
     }
 
     [ObservableProperty]
@@ -76,6 +77,8 @@ public partial class GenerateWalletWithPasswordViewModel : BaseViewModel
 
             await DownloadWalletAsync(bolWallet);
 
+            _messenger.Send(Constants.WalletCreatedMessage);
+            
             await NavigationService.NavigateTo<DownloadCertificationDocumentsViewModel>();
         }
         catch (Exception ex)


### PR DESCRIPTION
## What does this fix?
The issue lied with the already created `BolService` instance, which was injected in the `CreateCodenameViewModel` VM. This is used to check for alternative names.

During this step no BolWallet exists yet, so this instance has a dependency to `IOption<BolWallet>` which is basically empty.

After a wallet was created, navigation moved to `MainWithAccountViewModel`, which simply reused the same `BolService` instance, as resolved by `BolServiceFactory`.

To circumvent this, a new message was introduced named `WalletCreatedMessage`, similar to `WalletClosedMessage` to be used with the same purpose. The message is fired after the wallet is created and right before navigation moves to the page where the user downloads their files. `BolServiceFactory` is now a recipient of `WalletCreatedMessage` and immediately disposes the internal service scope it uses to resolve `BolService` instances.

Thus, by the time navigation moves to load the `MainWithAccountViewModel`, where a new instance of `IBolService` will be requested, the factory will see that there is no internal scope yet, only to create a new one and resolve the service, ensuring a new instance is created at this moment. The new instance will get a new `IOptions<BolWallet>` dependency which now points to the newly created wallet properly.

### Other changes
`BolServiceFactory` took a direct dependency to the static instance of `WeakReferenceMesseger`, so this was changed to use dependency injection of `IMessenger`.