### PR TITLE
Cancel Register/Whitelist check loops after closing the wallet

### DIFF
--- a/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
+++ b/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
@@ -14,6 +14,8 @@ public partial class MainWithAccountViewModel : BaseViewModel
     private readonly INetworkPreferences _networkPreferences;
     private readonly ICloseWalletService _closeWalletService;
 
+    private readonly CancellationTokenSource _cts = new();
+
     public string WelcomeText => "Welcome";
     public string BalanceText => "Total Balance";
     public string AccountText => "Account";
@@ -168,16 +170,22 @@ public partial class MainWithAccountViewModel : BaseViewModel
 
             await _bolService.Register(token);
 
-            while (!IsRegistered)
+            var cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, token);
+            
+            while (!IsRegistered && !cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(TimeSpan.FromSeconds(5), token);
-                await FetchBolAccountData(token);
+                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken.Token);
+                await FetchBolAccountData(cancellationToken.Token);
             }
-            await Toast.Make("Your Account has been registered.").Show();
+
+            if (IsRegistered)
+            {
+                await Toast.Make("Your Account has been registered.").Show(token);
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not TaskCanceledException)
         {
-            await Toast.Make(ex.Message).Show();
+            await Toast.Make(ex.Message).Show(token);
         }
         finally
         {
@@ -195,16 +203,22 @@ public partial class MainWithAccountViewModel : BaseViewModel
             Uri uri = new Uri($"{_networkPreferences.TargetNetworkConfig.BolCertifierEndpoint}/{MainAddress}");
             await Browser.Default.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
             
-            while (!IsWhiteListed)
+            var cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, token);
+            
+            while (!IsWhiteListed && !cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(TimeSpan.FromSeconds(5), token);
-                await FetchBolAccountData(token);
+                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken.Token);
+                await FetchBolAccountData(cancellationToken.Token);
             }
-            await Toast.Make("Your Main Address has been Whitelisted.").Show();
+
+            if (IsWhiteListed)
+            {
+                await Toast.Make("Your Main Address has been Whitelisted.").Show(token);
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not TaskCanceledException)
         {
-            await Toast.Make(ex.Message).Show();
+            await Toast.Make(ex.Message).Show(token);
         }
         finally
         {
@@ -249,5 +263,9 @@ public partial class MainWithAccountViewModel : BaseViewModel
     }
 
     [RelayCommand]
-    private async Task CloseWallet() => await _closeWalletService.CloseWallet();
+    private async Task CloseWallet()
+    {
+        await _cts.CancelAsync();
+        await _closeWalletService.CloseWallet();
+    }   
 }

--- a/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
+++ b/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
@@ -5,7 +5,7 @@ using Bol.Core.Rpc.Model;
 using CommunityToolkit.Maui.Alerts;
 
 namespace BolWallet.ViewModels;
-public partial class MainWithAccountViewModel : BaseViewModel
+public partial class MainWithAccountViewModel : BaseViewModel, IDisposable
 {
     private readonly ISecureRepository _secureRepository;
     private readonly IBolService _bolService;
@@ -268,4 +268,14 @@ public partial class MainWithAccountViewModel : BaseViewModel
         await _cts.CancelAsync();
         await _closeWalletService.CloseWallet();
     }   
+
+    public void Dispose()
+    {
+        if (_cts is { IsCancellationRequested: false })
+        {
+            _cts.Cancel();
+        }
+        
+        _cts.Dispose();
+    }
 }

--- a/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
+++ b/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
@@ -149,7 +149,7 @@ public partial class MainWithAccountViewModel : BaseViewModel
             catch (RpcException ex)
             {
                 IsWhiteListed = false;
-                await Toast.Make(ex.Message).Show();
+                await Toast.Make(ex.Message).Show(token);
             }
 
             CanWhiteList = !IsWhiteListed && !IsRegistered;
@@ -157,7 +157,7 @@ public partial class MainWithAccountViewModel : BaseViewModel
         }
         catch (Exception ex)
         {
-            await Toast.Make(ex.Message).Show();
+            await Toast.Make(ex.Message).Show(token);
         }
     }
 

--- a/src/BolWallet/Views/MainWithAccountPage.xaml.cs
+++ b/src/BolWallet/Views/MainWithAccountPage.xaml.cs
@@ -9,6 +9,8 @@ public partial class MainWithAccountPage : ContentPage
         _mainWithAccountViewModel = mainWithAccountViewModel;
         InitializeComponent();
         BindingContext = _mainWithAccountViewModel;
+
+        Unloaded += (_, _) => _mainWithAccountViewModel?.Dispose();
     }
 
 	protected override async void OnAppearing()


### PR DESCRIPTION
Currently, when an infinite register or whitelist check loop starts, until the account is registered or whitelisted.

This is problematic if the wallet close action is used, since the commands weren't using tokens properly.

With this PR, cancellation is done properly when the wallet closes and also the viewmodel is disposed when the page is unloaded to clean up the CancellationTokenSource instance it uses internally.