### PR TITLE
Add the ability to close the wallet when in GetCertifiedPage

### DIFF
--- a/src/BolWallet/ViewModels/GetCertifiedViewModel.cs
+++ b/src/BolWallet/ViewModels/GetCertifiedViewModel.cs
@@ -8,16 +8,19 @@ public partial class GetCertifiedViewModel : BaseViewModel
     private readonly ISecureRepository _secureRepository;
     private readonly IBolService _bolService;
     private readonly IFileDownloadService _fileDownloadService;
+    private readonly ICloseWalletService _closeWalletService;
 
     public GetCertifiedViewModel(
         INavigationService navigationService,
         ISecureRepository secureRepository,
         IBolService bolService,
-        IFileDownloadService fileDownloadService) : base(navigationService)
+        IFileDownloadService fileDownloadService,
+        ICloseWalletService closeWalletService) : base(navigationService)
     {
         _secureRepository = secureRepository;
         _bolService = bolService;
         _fileDownloadService = fileDownloadService;
+        _closeWalletService = closeWalletService;
     }
 
     [ObservableProperty]
@@ -49,6 +52,11 @@ public partial class GetCertifiedViewModel : BaseViewModel
 
     [ObservableProperty]
     private List<CertifierListItem> _certifiers = new();
+
+    [ObservableProperty]
+    private bool _doesNotSupportsThreeDotMenuToolbarItem =
+        DeviceInfo.Platform == DevicePlatform.iOS || 
+        DeviceInfo.Platform == DevicePlatform.MacCatalyst;
 
     public async Task Initialize(CancellationToken token)
     {
@@ -279,6 +287,9 @@ public partial class GetCertifiedViewModel : BaseViewModel
     {
         await _fileDownloadService.DownloadDataAsync(userData.BolWallet, "BolWallet.json", cancellationToken);
     }
+
+    [RelayCommand]
+    private async Task CloseWallet() => await _closeWalletService.CloseWallet();
 }
 
 public class CertifierListItem

--- a/src/BolWallet/Views/GetCertifiedPage.xaml
+++ b/src/BolWallet/Views/GetCertifiedPage.xaml
@@ -15,29 +15,28 @@
     </ContentPage.Resources>
     
 	<ContentPage.ToolbarItems>
+        <ToolbarItem
+            Text="Download Certification Files"
+            Order="Primary"
+            Priority="0" 
+            Command="{Binding DownloadEdiFilesCommand}"
+            IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
         <ToolbarItem 
 		    Text="Download BolAccount"
 		    Order="Secondary"
-		    Priority="0" 
+		    Priority="1" 
 		    Command="{Binding DownloadAccountCommand}"
             IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
 		<ToolbarItem 
 		    Text="Download BolWallet"
 		    Order="Secondary"
-		    Priority="1" 
+		    Priority="2" 
 		    Command="{Binding DownloadBolWalletCommand}"
             IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
-		<ToolbarItem
-		    Text="Download Certification Files"
-		    Order="Primary"
-		    Priority="0" 
-		    Command="{Binding DownloadEdiFilesCommand}"
-            IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
-        
         <ToolbarItem 
             Text="Close Wallet"
             Order="Secondary"
-            Priority="2" 
+            Priority="3" 
             Command="{Binding CloseWalletCommand}" 
             IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}"/>
 	</ContentPage.ToolbarItems>

--- a/src/BolWallet/Views/GetCertifiedPage.xaml
+++ b/src/BolWallet/Views/GetCertifiedPage.xaml
@@ -7,8 +7,9 @@
              x:DataType="viewModels:GetCertifiedViewModel"
              xmlns:helpers="clr-namespace:BolWallet.Helpers"
              Title="Certify Your Account"
-			 BackgroundColor="{DynamicResource SecondaryColor}">
-
+			 BackgroundColor="{DynamicResource SecondaryColor}"
+             NavigationPage.HasBackButton="False">
+    
     <ContentPage.Resources>
         <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
     </ContentPage.Resources>

--- a/src/BolWallet/Views/GetCertifiedPage.xaml
+++ b/src/BolWallet/Views/GetCertifiedPage.xaml
@@ -14,7 +14,7 @@
     </ContentPage.Resources>
     
 	<ContentPage.ToolbarItems>
-		<ToolbarItem 
+        <ToolbarItem 
 		    Text="Download BolAccount"
 		    Order="Secondary"
 		    Priority="0" 
@@ -23,20 +23,47 @@
 		<ToolbarItem 
 		    Text="Download BolWallet"
 		    Order="Secondary"
-		    Priority="0" 
+		    Priority="1" 
 		    Command="{Binding DownloadBolWalletCommand}"
             IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
-		<ToolbarItem 
+		<ToolbarItem
 		    Text="Download Certification Files"
 		    Order="Primary"
 		    Priority="0" 
 		    Command="{Binding DownloadEdiFilesCommand}"
             IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
+        
+        <ToolbarItem 
+            Text="Close Wallet"
+            Order="Secondary"
+            Priority="2" 
+            Command="{Binding CloseWalletCommand}" 
+            IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}"/>
 	</ContentPage.ToolbarItems>
 
 	<ScrollView>
 		<StackLayout>
-			<StackLayout Spacing="15" Padding="10" Margin="10,10,20,10" >
+            <StackLayout Spacing="15" Padding="10" Margin="10,10,20,10"
+                         IsVisible="{Binding DoesNotSupportsThreeDotMenuToolbarItem}">
+                <Button 
+                    Text="Download Certification Files"
+                    BackgroundColor="{DynamicResource Primary}"
+                    TextColor="White"
+                    Command="{Binding DownloadEdiFilesCommand}"
+                    IsVisible="{Binding DoesNotSupportsThreeDotMenuToolbarItem}" />
+                <Button 
+                    Text="Download BoL Account"
+                    BackgroundColor="{DynamicResource Primary}"
+                    TextColor="White"
+                    Command="{Binding DownloadAccountCommand}" />
+                <Button 
+                    Text="Download BoL Wallet"
+                    BackgroundColor="{DynamicResource Primary}"
+                    TextColor="White"
+                    Command="{Binding DownloadBolWalletCommand}" />
+            </StackLayout>
+            
+            <StackLayout Spacing="15" Padding="10" Margin="10,10,20,10" >
 				<Label  Text="Refresh" IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" VerticalTextAlignment="End" HorizontalTextAlignment="End" FontSize="Small"/>
 				<ImageButton IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" Command="{Binding RefreshCommand}" VerticalOptions="Start" HorizontalOptions="EndAndExpand">
 					<ImageButton.Source>

--- a/src/BolWallet/Views/GetCertifiedPage.xaml.cs
+++ b/src/BolWallet/Views/GetCertifiedPage.xaml.cs
@@ -10,7 +10,20 @@ public partial class GetCertifiedPage : ContentPage
 	{
 		InitializeComponent();
 		BindingContext = getCertifiedViewModel;
-	}
+
+        if (DeviceInfo.Platform != DevicePlatform.iOS &&
+            DeviceInfo.Platform != DevicePlatform.MacCatalyst)
+        {
+            return;
+        }
+
+        var closeWalletToolbarItem = ToolbarItems.First(x => x.Text == "Close Wallet");
+        closeWalletToolbarItem.Order = ToolbarItemOrder.Primary;
+        closeWalletToolbarItem.IconImageSource = ImageSource.FromFile("logout");
+        
+        ToolbarItems.Clear();
+        ToolbarItems.Add(closeWalletToolbarItem);
+    }
 	protected override async void OnAppearing()
 	{
 		base.OnAppearing();


### PR DESCRIPTION
## New feature

Adds the same close wallet toolbar action as the one previously added for the `MainWithAccountPage`. This differs per platform because of how [toolbar items behave differently between iOS/MacCatalyst and Android/Windows](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/toolbaritem?view=net-maui-8.0#primary-and-secondary-toolbar-items).

- Android/Windows shows the action as the last action in the 3-dot menu.
<img width="240" alt="image" src="https://github.com/user-attachments/assets/90523c98-2d41-45b9-b5cb-d52637e18c1a">

- iOS/MacCatalyst only show the logout icon to match `MainWithAccountPage` and removes all other toolbar items to avoid them showing either in the toolbar or underneath it as a horizontal list, which are then shown as separate buttons at the top of the page.

<img width="240" alt="image" src="https://github.com/user-attachments/assets/c0d23e6e-a1cd-48bf-a589-88e9f86f2faf">

## Other changes

The page doesn't has a back button anymore, since this moved back to `MainWithAccountPage`, which automatically navigated to `GetCertifiedPage` again.