### PR TITLE
Enhance network switch with a verification prompt

### DIFF
--- a/src/BolWallet/ViewModels/MainViewModel.cs
+++ b/src/BolWallet/ViewModels/MainViewModel.cs
@@ -61,17 +61,25 @@ public partial class MainViewModel : BaseViewModel
     [RelayCommand]
     private async Task SwitchNetwork()
     {
-        var confirm = await Application.Current.MainPage.DisplayAlert(
+        var prompt = await Application.Current.MainPage.DisplayPromptAsync(
             "Network Change",
-            $"The target network will change from {_networkPreferences.Name} to {_networkPreferences.AlternativeName}!!!",
-            $"Yes, change to {_networkPreferences.AlternativeName}!",
-            "Cancel, I don't know what I'm doing!");
+            $"You are currently connected to {_networkPreferences.Name}." +
+            $"{Environment.NewLine}{Environment.NewLine}" +
+            $"To switch to {_networkPreferences.AlternativeName}, type its name below:",
+            keyboard: Keyboard.Plain,
+            initialValue: "",
+            accept: $"Yes, change to {_networkPreferences.AlternativeName}!",
+            cancel: "Cancel, I don't know what I'm doing!");
         
-        if (!confirm)
+        if (string.IsNullOrWhiteSpace(prompt) || !prompt.Equals(_networkPreferences.AlternativeName))
         {
+            await Application.Current.MainPage.DisplayAlert("Network Change",
+                $"{_networkPreferences.AlternativeName} network name wasn't verified, no switch will occur.",
+                "OK");
+            
             return;
         }
-
+        
         IsLoading = true;
         LoadingText = "Changing network...";
         
@@ -82,6 +90,10 @@ public partial class MainViewModel : BaseViewModel
 
         LoadingText = string.Empty;
         IsLoading = false;
+        
+        await Application.Current.MainPage.DisplayAlert("Network Change",
+            $"Switch to {_networkPreferences.Name} network completed successfully.",
+            "OK");
     }
     
     [RelayCommand]


### PR DESCRIPTION
This adds one extra safety layer for users triggering the network switch by mistake, since the app now asks the user to input the target network's name otherwise the change never occurs.

Double-tapping/clicking on the BoL logo will display the new prompt:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/0951f6eb-ef97-4e52-9128-0d7eb6e63629">

Cancelling or typing the wrong name cancels the switch and notifies the user:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/8cf29a4a-5f73-466c-9ec4-43d7d327c4c7">

After a successful network switch a final alert is displayed about the switch being completed:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/b0898529-c929-4e99-ab3c-26be2d307724">
