### PR TITLE
Improve wallet cleanup

### DIFF
--- a/src/BolWallet/Constants.cs
+++ b/src/BolWallet/Constants.cs
@@ -18,6 +18,7 @@ internal class Constants
     public static readonly TargetNetworkChangedMessage TargetNetworkChangedMessage = new();
     public static readonly WalletClosedMessage WalletClosedMessage = new();
     public static readonly WalletCreatedMessage WalletCreatedMessage = new();
+    public static readonly WalletCleanupCompletedMessage WalletCleanupCompletedMessage = new();
     
     public static readonly JsonSerializerOptions WalletJsonSerializerDefaultOptions = new()
     {

--- a/src/BolWallet/Models/Messages/WalletCleanupCompletedMessage.cs
+++ b/src/BolWallet/Models/Messages/WalletCleanupCompletedMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace BolWallet.Models.Messages;
+
+public record WalletCleanupCompletedMessage;


### PR DESCRIPTION
Fixes an issue with leftover memory after closing a wallet which manifested only on Windows.

Regardless, the fix applies to all platforms and makes the wallet memory change more robust.