### PR TITLE
Extend caching to remove keys and override BOL SDK's cache

### DIFF
--- a/src/BolWallet/Extensions/ConfigureWalletExtensions.cs
+++ b/src/BolWallet/Extensions/ConfigureWalletExtensions.cs
@@ -53,18 +53,8 @@ public static class ConfigureWalletExtensions
             return Options.Create(new BolConfig { RpcEndpoint = targetNetworkConfig.RpcEndpoint, Contract = targetNetworkConfig.Contract });
         });
 
-        // Re-register SDK's Cache as scoped instead of the default singleton
-        // to make sure it's disposed and new BolService instances don't use the same instance.
-        // This avoids loading the same BolContext as the loaded first,
-        // even after closing a wallet and opening another.
-        services.AddScoped<ICachingService>(provider =>
-        {
-            var cacheOptions = Options.Create(new MemoryCacheOptions { });
-
-            var memoryCache = new MemoryCache(cacheOptions);
-
-            return new CachingService(memoryCache);
-        });
+        // Re-register SDK's Cache to use IAppCaching which the app uses as a singleton memory cache.
+        services.AddSingleton<ICachingService>(sp => sp.GetRequiredService<IAppCaching>());
 
         return services;
 	}

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -90,6 +90,9 @@ public static class MauiProgram
             };
         });
 
+        services.AddMemoryCache();
+        services.AddSingleton<IAppCaching, AppCaching>();
+        
         services.ConfigureWalletServices();
 
         services.AddTransient<IBase64Encoder, Base64Encoder>();

--- a/src/BolWallet/Services/Abstractions/IAppCaching.cs
+++ b/src/BolWallet/Services/Abstractions/IAppCaching.cs
@@ -1,0 +1,8 @@
+﻿using Bol.Core.Abstractions;
+
+namespace BolWallet.Services.Abstractions;
+
+public interface IAppCaching : ICachingService
+{
+    void Remove(string key);
+}

--- a/src/BolWallet/Services/AppCaching.cs
+++ b/src/BolWallet/Services/AppCaching.cs
@@ -1,0 +1,14 @@
+﻿using Bol.Core.Services;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace BolWallet.Services;
+
+public class AppCaching(IMemoryCache memoryCache) : CachingService(memoryCache), IAppCaching
+{
+    private readonly IMemoryCache _memoryCache = memoryCache;
+
+    public void Remove(string key)
+    {
+        _memoryCache.Remove(key);
+    }
+}

--- a/src/BolWallet/Services/BolServiceFactory.cs
+++ b/src/BolWallet/Services/BolServiceFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Bol.Core.Abstractions;
+using Bol.Core.Model;
 using Bol.Core.Services;
 using BolWallet.Models.Messages;
 using CommunityToolkit.Mvvm.Messaging;
@@ -11,16 +12,19 @@ public class BolServiceFactory : IRecipient<WalletClosedMessage>, IRecipient<Wal
     private IServiceScope _serviceScope;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IMessenger _messenger;
+    private readonly IAppCaching _cache;
     private readonly ILogger<BolServiceFactory> _logger;
 
     public BolServiceFactory(
         IServiceScopeFactory serviceScopeFactory,
         IMessenger messenger,
+        IAppCaching cache,
         ILogger<BolServiceFactory> logger)
     {
         _serviceScopeFactory = serviceScopeFactory;
-        _logger = logger;
         _messenger = messenger;
+        _cache = cache;
+        _logger = logger;
         
         messenger.Register<WalletClosedMessage>(this);
         messenger.Register<WalletCreatedMessage>(this);
@@ -46,6 +50,8 @@ public class BolServiceFactory : IRecipient<WalletClosedMessage>, IRecipient<Wal
 
     private void Cleanup()
     {
+        // Clean cache from the cached wallet using the same key used by the BoL SDK.
+        _cache.Remove(CacheKeyNames.BolContext.ToString());
         _serviceScope?.Dispose();
         _serviceScope = null;
         SendCleanupMessage();

--- a/src/BolWallet/ViewModels/CompleteBolLoginChallengeViewModel.cs
+++ b/src/BolWallet/ViewModels/CompleteBolLoginChallengeViewModel.cs
@@ -2,6 +2,7 @@
 using Bol.Cryptography;
 using Bol.Cryptography.Abstractions;
 using CommunityToolkit.Maui.Alerts;
+using Microsoft.Extensions.Logging;
 
 namespace BolWallet.ViewModels;
 
@@ -14,41 +15,54 @@ public partial class CompleteBolLoginChallengeViewModel : BaseViewModel
     private readonly IECCurveSigner _signer;
     private readonly IBase64Encoder _base64Encoder;
     private readonly IBolChallengeService _bolChallengeService;
+    private readonly ILogger<CompleteBolLoginChallengeViewModel> _logger;
 
     public CompleteBolLoginChallengeViewModel(
         INavigationService navigationService,
         IContextAccessor contextAccessor,
         IECCurveSigner signer,
         IBase64Encoder base64Encoder,
-        IBolChallengeService bolChallengeService) : base(navigationService)
+        IBolChallengeService bolChallengeService,
+        ILogger<CompleteBolLoginChallengeViewModel> logger) : base(navigationService)
     {
         _contextAccessor = contextAccessor;
         _signer = signer;
         _base64Encoder = base64Encoder;
         _bolChallengeService = bolChallengeService;
+        _logger = logger;
     }
 
     [RelayCommand]
     private async Task CompleteBolChallenge(CancellationToken token = default)
     {
-        var context = _contextAccessor.GetContext();
-        var keyPair = context.SocialAddress.Value;
-        var publicKeyBytes = keyPair.PublicKey.ToBytes();
-
-        var challenge = _base64Encoder.Decode(Challenge);
-        var signature = _signer.Sign(challenge, keyPair.PrivateKey, publicKeyBytes);
-        
-        var signatureString = _base64Encoder.Encode(signature);
-        var publicKey = _base64Encoder.Encode(publicKeyBytes);
-        
-        var result = await _bolChallengeService.CompleteChallenge(Challenge, signatureString, publicKey, context.CodeName, token);
-        if (result.IsFailed)
+        try
         {
-            await Toast.Make(result.Message).Show(token);
-            return;
-        }
+            var context = _contextAccessor.GetContext();
+            var keyPair = context.SocialAddress.Value;
+            var publicKeyBytes = keyPair.PublicKey.ToBytes();
 
-        await Toast.Make("BoL Login Challenge completed!").Show(token);
-        await NavigationService.NavigateTo<MainWithAccountViewModel>(true);
+            var challenge = _base64Encoder.Decode(Challenge);
+            var signature = _signer.Sign(challenge, keyPair.PrivateKey, publicKeyBytes);
+
+            var signatureString = _base64Encoder.Encode(signature);
+            var publicKey = _base64Encoder.Encode(publicKeyBytes);
+
+            var result =
+                await _bolChallengeService.CompleteChallenge(Challenge, signatureString, publicKey, context.CodeName,
+                    token);
+            if (result.IsFailed)
+            {
+                await Toast.Make(result.Message).Show(token);
+                return;
+            }
+
+            await Toast.Make("BoL Login Challenge completed!").Show(token);
+            await NavigationService.NavigateBack();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error completing BoL Challenge {BoLChallenge}", Challenge);
+            await Toast.Make($"BoL Login Challenge failed with error:{Environment.NewLine}{ex.Message}").Show(token);
+        }
     }
 }


### PR DESCRIPTION
Fixes #205 

The issue was with the recent change to register `ICachingService` as scoped in an attempt to dispose it when cleaning up.

But there was a case where this was injected as a new instance after having opened a wallet and when during an action where the user tried to complete a BoL Challenge (to complete an identity sign in), there was no cached bol context but the BOL SDK was already operating with an open wallet.

This resulted in trying to load the bol context for the wallet again which hang the app.

The issue is resolved by introducing `IAppCaching` and `AppCaching` as singleton, which extends `ICachingService` from BoL SDK with the ability to remove a cached entry. When the wallet closes, the cached bol context is removed. Also, `ICachingService` is re-registered as a singleton by delegating its resolution to the singleton `IAppCaching`, so both the app and the BoL SDK can use the same app-wide instance.

Since this is a singleton, the cached bol context is cached and accessed properly when completing a BoL Challenge, so #205 is fixed.