### PR TITLE
[GetCertifiedPage] Make back button visible if account is open

### DIFF
--- a/src/BolWallet/ViewModels/PreloadViewModel.cs
+++ b/src/BolWallet/ViewModels/PreloadViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Maui.Alerts;
+using Microsoft.Extensions.Logging;
 
 namespace BolWallet.ViewModels;
 
@@ -8,42 +9,58 @@ public partial class PreloadViewModel : BaseViewModel
     private readonly INetworkPreferences _networkPreferences;
     private readonly ICountriesService _countriesService;
     private readonly ISecureRepository _secureRepository;
+    private readonly ILogger _logger;
 
     public PreloadViewModel(
         INavigationService navigationService,
         IBolRpcService bolRpcService,
         INetworkPreferences networkPreferences,
         ICountriesService countriesService,
-        ISecureRepository secureRepository) : base(navigationService)
+        ISecureRepository secureRepository,
+        ILogger<PreloadViewModel> logger) : base(navigationService)
     {
         _bolRpcService = bolRpcService;
         _networkPreferences = networkPreferences;
         _countriesService = countriesService;
         _secureRepository = secureRepository;
+        _logger = logger;
     }
     
     public override async Task OnInitializedAsync()
     {
-        var result = await _bolRpcService.GetBolContractHash(CancellationToken.None);
-        if (result.IsFailed)
+        try
         {
-            await Toast.Make(result.Message).Show(CancellationToken.None);
-            return;
+            await LoadAndNavigate();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load user and navigate to main viewmodel during preload...");
+            throw;
         }
 
-        _networkPreferences.SetBolContractHash(result.Data);
-        
-        _ = await _countriesService.GetAsync();
-        
-        UserData userData = _secureRepository.Get<UserData>("userdata");
+        async Task LoadAndNavigate()
+        {
+            var result = await _bolRpcService.GetBolContractHash(CancellationToken.None);
+            if (result.IsFailed)
+            {
+                await Toast.Make(result.Message).Show(CancellationToken.None);
+                return;
+            }
 
-        if (userData?.BolWallet == null)
-        {
-            await NavigationService.NavigateTo<MainViewModel>(changeRoot: true);
-        }
-        else
-        {
-            await NavigationService.NavigateTo<MainWithAccountViewModel>(changeRoot: true);
+            _networkPreferences.SetBolContractHash(result.Data);
+        
+            _ = await _countriesService.GetAsync();
+        
+            UserData userData = _secureRepository.Get<UserData>("userdata");
+
+            if (userData?.BolWallet == null)
+            {
+                await NavigationService.NavigateTo<MainViewModel>(changeRoot: true);
+            }
+            else
+            {
+                await NavigationService.NavigateTo<MainWithAccountViewModel>(changeRoot: true);
+            }
         }
     }
 }

--- a/src/BolWallet/Views/GetCertifiedPage.xaml
+++ b/src/BolWallet/Views/GetCertifiedPage.xaml
@@ -8,7 +8,7 @@
              xmlns:helpers="clr-namespace:BolWallet.Helpers"
              Title="Certify Your Account"
 			 BackgroundColor="{DynamicResource SecondaryColor}"
-             NavigationPage.HasBackButton="False">
+             NavigationPage.HasBackButton="{Binding IsAccountOpen}">
     
     <ContentPage.Resources>
         <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />


### PR DESCRIPTION
## Fixes #206 

If an account is open, then it's OK to show the back button, since the user came to this page from the home page after opening a wallet. This is the case of a user trying to request more certifications, eg. when trying to become a certifier.

If the account is not open, which means the user is either at the whitelist or register phase, then they can't do anything else with the app anyway and the certifications page is the only page they can see, so hiding the button is OK, as it was introduced in #200.

Ideally the home page will be enhanced to support both open and pending accounts so allowing the user to go back from the certifications page will make sense, in which case the back button can be made visible again.

## Other changes
Logging is added during `PreloadViewModel`'s initialization to capture possible errors in the app log.