### PR TITLE
Upgrade to NET9 and MAUI 9.0.0

### DIFF
--- a/src/BolWallet/App.xaml.cs
+++ b/src/BolWallet/App.xaml.cs
@@ -8,7 +8,7 @@ public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
 {
     private readonly INetworkPreferences _networkPreferences;
 
-    public App(PreloadPage preloadPage, INetworkPreferences networkPreferences, IMessenger messenger)
+    public App(INetworkPreferences networkPreferences, IMessenger messenger)
 	{
         _networkPreferences = networkPreferences;
         InitializeComponent();
@@ -40,15 +40,12 @@ public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
 				handler.PlatformView.BorderStyle = UIKit.UITextBorderStyle.None;
 #endif
 			});
-
-        MainPage = new NavigationPage(preloadPage);
     }
     
     protected override Window CreateWindow(IActivationState activationState)
     {
-        Window window = base.CreateWindow(activationState);
-        window.Title = CreateWindowTitle();
-        return window;
+        var preloadPage = activationState.Context.Services.GetRequiredService<PreloadPage>();
+        return new Window { Title = CreateWindowTitle(), Page = new NavigationPage(preloadPage) };
     }
 
 #if WINDOWS
@@ -77,7 +74,7 @@ public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
 #endif
     public void Receive(TargetNetworkChangedMessage message)
     {
-        MainThread.BeginInvokeOnMainThread(() => Current.MainPage.Window.Title = CreateWindowTitle());
+        MainThread.BeginInvokeOnMainThread(() => Current.Windows[0].Page.Window.Title = CreateWindowTitle());
     }
 
     private string CreateWindowTitle() => _networkPreferences.IsMainNet

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('macos'))">$(TargetFrameworks);net8.0-maccatalyst;net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net9.0-android;</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('macos'))">$(TargetFrameworks);net9.0-maccatalyst;net9.0-ios</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>BolWallet</RootNamespace>
     <UseMaui>true</UseMaui>
-    <MauiVersion>8.0.92</MauiVersion>
+    <MauiVersion>9.0.0</MauiVersion>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
 
@@ -24,19 +24,19 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
 
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
     <WarningsAsErrors />
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
@@ -44,20 +44,20 @@
     <CodesignProvision>Automatic</CodesignProvision>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
     <WarningsAsErrors />
     <AndroidLinkTool>r8</AndroidLinkTool>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
     <WarningsAsErrors />
     <ArchiveOnBuild>true</ArchiveOnBuild>
     <CodesignProvision>Automatic</CodesignProvision>
@@ -65,7 +65,7 @@
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
     <WarningsAsErrors />
     <MtouchLink>SdkOnly</MtouchLink> 
     <CreatePackage>true</CreatePackage>
@@ -77,7 +77,7 @@
     <CodesignEntitlements>Platforms\MacCatalyst\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
@@ -218,10 +218,9 @@
     <PackageReference Include="BolChain.Core" Version="1.1.4" />
     <PackageReference Include="CommunityToolkit.Maui" Version="8.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+<!--    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />-->
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
     <PackageReference Include="Plugin.Maui.Audio" Version="2.1.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -213,7 +213,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="akavache" Version="9.1.20" />
+    <PackageReference Include="akavache" Version="10.1.6" />
     <PackageReference Include="Blazing.Mvvm" Version="1.4.0" />
     <PackageReference Include="BolChain.Core" Version="1.1.4" />
     <PackageReference Include="CommunityToolkit.Maui" Version="8.0.1" />

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -35,6 +35,7 @@ public static class MauiProgram
                 fonts.AddFont("MaterialIcons-Regular.ttf", "MaterialIconsRegular");
             });
 
+        builder.Services.AddSingleton<IAppVersion, AppVersion>();
         builder.Services.AddMauiBlazorWebView();
 
         builder.Services.AddMudServices();

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -45,6 +45,13 @@ public static class MauiProgram
 #else
         builder.AddConfiguration("BolWallet.appsettings.json");
 #endif
+        
+#if IOS || MACCATALYST
+builder.ConfigureMauiHandlers(handlers =>
+{
+    handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
+});
+#endif
 
         var services = builder.Services;
 

--- a/src/BolWallet/Pages/CitizenshipPage.razor
+++ b/src/BolWallet/Pages/CitizenshipPage.razor
@@ -108,6 +108,6 @@
             return;
         }
 
-        await App.Current.MainPage.Navigation.PushAsync(new Views.EcryptedCitizenshipPage());
+        await Application.Current.Windows[0].Page.Navigation.PushAsync(new Views.EcryptedCitizenshipPage());
     }
 }

--- a/src/BolWallet/Pages/MenuPanel.razor
+++ b/src/BolWallet/Pages/MenuPanel.razor
@@ -2,6 +2,7 @@
 @inject INavigationService NavigationService
 @inject IBolService bolService;
 @inject ICloseWalletService closeWalletService;
+@inject IAppVersion AppVersion;
 
 <MudLayout>
     <MudAppBar Style="background-color:#0050FF">
@@ -12,7 +13,10 @@
     </MudAppBar>
     <MudDrawer @bind-Open="@open" Variant="@DrawerVariant.Responsive" PreserveOpenState="true">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">Bol Menu</MudText>
+            <MudList>
+                <MudText Typo="Typo.h6">BOL Wallet</MudText>
+                <MudText Typo="Typo.caption">@(AppVersion.GetVersion())</MudText>
+            </MudList>
         </MudDrawerHeader>
         <MudNavMenu Bordered="true">
             <MudNavGroup Title="Transactions" Expanded="true">

--- a/src/BolWallet/Pages/MenuPanel.razor
+++ b/src/BolWallet/Pages/MenuPanel.razor
@@ -29,14 +29,14 @@
             <MudNavGroup Title="Certifier">
                 @if (!BolAccount.IsCertifier)
                 {
-                    <MudNavLink Icon="@Icons.Material.Rounded.SupervisorAccount" OnClick="() => App.Current.MainPage.Navigation.PushAsync(new Views.RegisterAsCertifierPage())">Become a Certifier</MudNavLink>
+                    <MudNavLink Icon="@Icons.Material.Rounded.SupervisorAccount" OnClick="() => App.Current.Windows[0].Page.Navigation.PushAsync(new Views.RegisterAsCertifierPage())">Become a Certifier</MudNavLink>
                 }
                 else
                 {
                     <MudNavLink Icon="@Icons.Material.Rounded.PersonAdd" OnClick="() => NavigationService.NavigateTo<CertifyViewModel>(true)">Certify a CodeName</MudNavLink>
                     <MudNavLink Icon="@Icons.Material.Rounded.AddModerator" OnClick="() => NavigationService.NavigateTo<WhitelistViewModel>(true)">Whitelist a Main Address</MudNavLink>
-                    <MudNavLink Icon="@Icons.Material.Rounded.LockPerson" OnClick="() => App.Current.MainPage.Navigation.PushAsync(new Views.AddMultiCitizenship())">Submit a Multiple Citizenship</MudNavLink>
-                    <MudNavLink Icon="@Icons.Material.Rounded.AttachMoney" OnClick="() => App.Current.MainPage.Navigation.PushAsync(new Views.SetCertifierFeePage())">Set Your Fee</MudNavLink>
+                    <MudNavLink Icon="@Icons.Material.Rounded.LockPerson" OnClick="() => App.Current.Windows[0].Page.Navigation.PushAsync(new Views.AddMultiCitizenship())">Submit a Multiple Citizenship</MudNavLink>
+                    <MudNavLink Icon="@Icons.Material.Rounded.AttachMoney" OnClick="() => App.Current.Windows[0].Page.Navigation.PushAsync(new Views.SetCertifierFeePage())">Set Your Fee</MudNavLink>
                     <MudNavLink Icon="@Icons.Material.Rounded.RemoveModerator" OnClick="() => ShowUnregisterConfirmation()">Unregister as Certifier</MudNavLink>
                 }
             </MudNavGroup>
@@ -83,7 +83,7 @@
     {
         try
         {
-            bool confirmed = await App.Current.MainPage.DisplayAlert("Confirm", "Are you sure you want to unregister as a certifier?", "Yes", "No");
+            bool confirmed = await App.Current.Windows[0].Page.DisplayAlert("Confirm", "Are you sure you want to unregister as a certifier?", "Yes", "No");
             if (confirmed)
             {
                 await bolService.UnRegisterAsCertifier();

--- a/src/BolWallet/Pages/WalletCreationInfo.razor
+++ b/src/BolWallet/Pages/WalletCreationInfo.razor
@@ -56,7 +56,7 @@
     {
         if (!IsNavigationDisabled)
         {
-            await App.Current.MainPage.Navigation.PushAsync(new Views.CitizenshipPage());
+            await App.Current.Windows[0].Page.Navigation.PushAsync(new Views.CitizenshipPage());
         }
     }
 }

--- a/src/BolWallet/Platforms/Android/AndroidManifest.xml
+++ b/src/BolWallet/Platforms/Android/AndroidManifest.xml
@@ -4,7 +4,6 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/src/BolWallet/Services/Abstractions/IAppVersion.cs
+++ b/src/BolWallet/Services/Abstractions/IAppVersion.cs
@@ -1,0 +1,6 @@
+﻿namespace BolWallet.Services.Abstractions;
+
+public interface IAppVersion
+{
+    string GetVersion();
+}

--- a/src/BolWallet/Services/AppVersion.cs
+++ b/src/BolWallet/Services/AppVersion.cs
@@ -1,0 +1,6 @@
+﻿namespace BolWallet.Services;
+
+public class AppVersion : IAppVersion
+{
+    public string GetVersion() => $"{AppInfo.Current.VersionString} ({AppInfo.Current.BuildString})";
+}

--- a/src/BolWallet/Services/CloseWalletService.cs
+++ b/src/BolWallet/Services/CloseWalletService.cs
@@ -21,7 +21,7 @@ public class CloseWalletService(
         
         logger.LogInformation("Close wallet requested...");
         
-        var confirm = await App.Current.MainPage.DisplayAlert(
+        var confirm = await App.Current.Windows[0].Page.DisplayAlert(
             "Close Wallet",
             "Closing your wallet will clear all user data, ensure you have saved your wallet and certification files first!",
             "I understand, close my wallet!",

--- a/src/BolWallet/Services/NavigationService.cs
+++ b/src/BolWallet/Services/NavigationService.cs
@@ -16,7 +16,7 @@ public class NavigationService : INavigationService
 	{
 		get
 		{
-			var navigation = Application.Current?.MainPage?.Navigation;
+			var navigation = Application.Current?.Windows[0].Page?.Navigation;
 
 			if (navigation is not null)
 			{

--- a/src/BolWallet/Services/PermissionServices/BasePermissionService.cs
+++ b/src/BolWallet/Services/PermissionServices/BasePermissionService.cs
@@ -38,7 +38,7 @@ public abstract class BasePermissionService : IPermissionService
     {
         var permissionName = typeof(T).Name;
 
-        var accepted = await Application.Current.MainPage.DisplayAlert(
+        var accepted = await Application.Current.Windows[0].Page.DisplayAlert(
             "Permission Required",
             $"To continue, please give {permissionName} permissions for this app in your device settings.",
             "Open Settings",

--- a/src/BolWallet/ViewModels/BolCommunityViewModel.cs
+++ b/src/BolWallet/ViewModels/BolCommunityViewModel.cs
@@ -53,13 +53,13 @@ public partial class BolCommunityViewModel : BaseViewModel
     [RelayCommand]
     private async Task NavigateToRegisterAsCertifierPage()
     {
-        await App.Current.MainPage.Navigation.PushAsync(new Views.RegisterAsCertifierPage());
+        await App.Current.Windows[0].Page.Navigation.PushAsync(new Views.RegisterAsCertifierPage());
     }
 
     [RelayCommand]
     private async Task NavigateToAddMultiCitizenship()
     {
-        await App.Current.MainPage.Navigation.PushAsync(new Views.AddMultiCitizenship());
+        await App.Current.Windows[0].Page.Navigation.PushAsync(new Views.AddMultiCitizenship());
     }
 
     [RelayCommand]
@@ -79,6 +79,6 @@ public partial class BolCommunityViewModel : BaseViewModel
     [RelayCommand]
     private async Task CompleteBolLoginChallenge()
     {
-        await App.Current.MainPage.Navigation.PushAsync(new Views.CompleteBolLoginChallengePage());
+        await App.Current.Windows[0].Page.Navigation.PushAsync(new Views.CompleteBolLoginChallengePage());
     }
 }

--- a/src/BolWallet/ViewModels/MainViewModel.cs
+++ b/src/BolWallet/ViewModels/MainViewModel.cs
@@ -131,9 +131,17 @@ public partial class MainViewModel : BaseViewModel
 
             var jsonString = await File.ReadAllTextAsync(pickResult.FullPath);
             
-            var passwordPopup = new PasswordPopup();
-            await Application.Current.MainPage.ShowPopupAsync(passwordPopup);
-            var password = await passwordPopup.TaskCompletionSource.Task;
+            // var passwordPopup = new PasswordPopup();
+            // await Application.Current.MainPage.ShowPopupAsync(passwordPopup);
+            // var password = await passwordPopup.TaskCompletionSource.Task;
+            
+            var password = await Application.Current.Windows[0].Page.DisplayPromptAsync(
+                "Unlock Wallet",
+                $"Type your password to unlock your wallet.",
+                keyboard: Keyboard.Password,
+                initialValue: "",
+                accept: "OK, unlock my wallet!",
+                cancel: "Cancel");
             
             if (string.IsNullOrEmpty(password)) return;
 

--- a/src/BolWallet/ViewModels/MainViewModel.cs
+++ b/src/BolWallet/ViewModels/MainViewModel.cs
@@ -61,7 +61,7 @@ public partial class MainViewModel : BaseViewModel
     [RelayCommand]
     private async Task SwitchNetwork()
     {
-        var prompt = await Application.Current.MainPage.DisplayPromptAsync(
+        var prompt = await Application.Current.Windows[0].Page.DisplayPromptAsync(
             "Network Change",
             $"You are currently connected to {_networkPreferences.Name}." +
             $"{Environment.NewLine}{Environment.NewLine}" +
@@ -73,7 +73,7 @@ public partial class MainViewModel : BaseViewModel
         
         if (string.IsNullOrWhiteSpace(prompt) || !prompt.Equals(_networkPreferences.AlternativeName))
         {
-            await Application.Current.MainPage.DisplayAlert("Network Change",
+            await Application.Current.Windows[0].Page.DisplayAlert("Network Change",
                 $"{_networkPreferences.AlternativeName} network name wasn't verified, no switch will occur.",
                 "OK");
             
@@ -91,7 +91,7 @@ public partial class MainViewModel : BaseViewModel
         LoadingText = string.Empty;
         IsLoading = false;
         
-        await Application.Current.MainPage.DisplayAlert("Network Change",
+        await Application.Current.Windows[0].Page.DisplayAlert("Network Change",
             $"Switch to {_networkPreferences.Name} network completed successfully.",
             "OK");
     }
@@ -105,7 +105,7 @@ public partial class MainViewModel : BaseViewModel
     [RelayCommand]
     private async Task NavigateToWalletCreationInfoPage()
     {
-        await App.Current.MainPage.Navigation.PushAsync(new Views.WalletCreationInfo());
+        await App.Current.Windows[0].Page.Navigation.PushAsync(new Views.WalletCreationInfo());
     }
 
     [RelayCommand]
@@ -143,7 +143,7 @@ public partial class MainViewModel : BaseViewModel
             var validPassword = await Task.Run(() => _walletService.CheckWalletPassword(jsonString, password));
             if (!validPassword)
             {
-                await Application.Current.MainPage.DisplayAlert(
+                await Application.Current.Windows[0].Page.DisplayAlert(
                     "Incorrect Password",
                     "Please provide a valid password.",
                     "OK");

--- a/src/BolWallet/ViewModels/PasswordPopup.cs
+++ b/src/BolWallet/ViewModels/PasswordPopup.cs
@@ -8,6 +8,8 @@ public sealed class PasswordPopup : Popup
 
     public PasswordPopup()
     {
+        CanBeDismissedByTappingOutsideOfPopup = false;
+        
         Color primaryBlue = Color.FromArgb("#0078D7");
         Color accentBlue = Color.FromArgb("#0052CC");
 
@@ -115,14 +117,6 @@ public sealed class PasswordPopup : Popup
         };
 
         Content = container;
-    }
-
-    protected override Task OnDismissedByTappingOutsideOfPopup(CancellationToken token)
-    {
-        base.OnDismissedByTappingOutsideOfPopup(token);
-        
-        TaskCompletionSource.TrySetResult(null);
-        return Task.CompletedTask;
     }
 }
 

--- a/src/BolWallet/ViewModels/PasswordPopup.cs
+++ b/src/BolWallet/ViewModels/PasswordPopup.cs
@@ -99,21 +99,21 @@ public sealed class PasswordPopup : Popup
 
         var container = new AbsoluteLayout
         {
-            HorizontalOptions = LayoutOptions.CenterAndExpand,
-            VerticalOptions = LayoutOptions.CenterAndExpand,
-            Margin = new Thickness(20, 100),
-            WidthRequest = 300,
-            HeightRequest = 400,
             Children =
-        {
-            boxView,
-            new VerticalStackLayout
             {
-                Children = { titleLabel, stackLayout },
-                Spacing = 10,
-                Padding = new Thickness(12)
+                boxView,
+                new VerticalStackLayout
+                {
+                    Children = { titleLabel, stackLayout },
+                    Spacing = 10,
+                    Padding = new Thickness(12),
+                    HorizontalOptions = LayoutOptions.CenterAndExpand,
+                    VerticalOptions = LayoutOptions.CenterAndExpand,
+                    Margin = new Thickness(20, 100),
+                    WidthRequest = 300,
+                    HeightRequest = 400,
+                }
             }
-        }
         };
 
         Content = container;

--- a/src/BolWallet/ViewModels/PreloadViewModel.cs
+++ b/src/BolWallet/ViewModels/PreloadViewModel.cs
@@ -55,11 +55,11 @@ public partial class PreloadViewModel : BaseViewModel
 
             if (userData?.BolWallet == null)
             {
-                await NavigationService.NavigateTo<MainViewModel>(changeRoot: true);
+                await NavigationService.NavigateTo<MainViewModel>();
             }
             else
             {
-                await NavigationService.NavigateTo<MainWithAccountViewModel>(changeRoot: true);
+                await NavigationService.NavigateTo<MainWithAccountViewModel>();
             }
         }
     }

--- a/src/BolWallet/Views/BolCommunityPage.xaml
+++ b/src/BolWallet/Views/BolCommunityPage.xaml
@@ -22,7 +22,6 @@
 
 			<Button
                 Grid.Row="0"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 Text="Get Certifications" 
 				Command="{Binding NavigateToGetCertificationsPageCommand}"
@@ -31,14 +30,12 @@
             <Button
 				Command="{Binding NavigateToWhitelistAndCertifyPageCommand}"
                 Grid.Row="1"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 IsEnabled="{Binding IsCertifier}"
                 Text="Whitelist and Certify" />
 
             <Button
                 Grid.Row="2"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 IsEnabled="{Binding IsCertifier}"
 	            Command="{Binding NavigateToAddMultiCitizenshipCommand}"
@@ -46,7 +43,6 @@
 
             <Button
                 Grid.Row="3"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 IsEnabled="{Binding IsCertifier, Converter={StaticResource InvertedBoolConverter}}"
 				Command="{Binding NavigateToRegisterAsCertifierPageCommand}"
@@ -54,7 +50,6 @@
 
             <Button
                 Grid.Row="4"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 IsEnabled="{Binding IsCertifier}"
                 Command="{Binding UnRegisterAsCertifierCommand}"
@@ -62,7 +57,6 @@
                 
             <Button
                 Grid.Row="5"
-                FontSize="12"
                 HorizontalOptions="FillAndExpand"
                 Command="{Binding CompleteBolLoginChallengeCommand}"
                 Text="Complete BoL Login Challenge" />

--- a/src/BolWallet/Views/ClaimPage.xaml
+++ b/src/BolWallet/Views/ClaimPage.xaml
@@ -103,7 +103,6 @@
 		<Button
 			IsVisible="{Binding IsClaimClickable}"
             FontAttributes="Bold"
-            FontSize="12"
             Command="{Binding ClaimCommand}"
             Text="Claim" />
 

--- a/src/BolWallet/Views/FinancialTransactionsPage.xaml
+++ b/src/BolWallet/Views/FinancialTransactionsPage.xaml
@@ -20,19 +20,16 @@
         <Button
                 Command="{Binding NavigateToTransferPageCommand}"
                 FontAttributes="Bold"
-                FontSize="12"
                 Text="Transfer" />
 
         <Button
                 Command="{Binding NavigateToTransferClaimPageCommand}"
                 IsEnabled="{Binding IsCompanyAccount, Converter={StaticResource InvertedBoolConverter}}"
                 FontAttributes="Bold"
-                FontSize="12"
                 Text="Transfer Claim" />
 
         <Button
                 FontAttributes="Bold"
-                FontSize="12"
                 Command="{Binding ClaimCommand}"
                 IsEnabled="{Binding IsCompanyAccount, Converter={StaticResource InvertedBoolConverter}}"
                 Text="Claim Your Bol" />

--- a/src/BolWallet/Views/MainPage.xaml
+++ b/src/BolWallet/Views/MainPage.xaml
@@ -8,6 +8,7 @@
     xmlns:controls1="clr-namespace:BolWallet.Controls"
     BackgroundColor="{DynamicResource SecondaryColor}"
     Title="{Binding Title}"
+    NavigationPage.HasBackButton="False"
     x:Name="this">
     
     <ContentPage.Resources>

--- a/src/BolWallet/Views/MainPage.xaml.cs
+++ b/src/BolWallet/Views/MainPage.xaml.cs
@@ -7,4 +7,9 @@ public partial class MainPage : ContentPage
         InitializeComponent();
 		BindingContext = mainViewModel;
     }
+
+    protected override bool OnBackButtonPressed()
+    {
+        return false;
+    }
 }

--- a/src/BolWallet/Views/MainWithAccountPage.xaml
+++ b/src/BolWallet/Views/MainWithAccountPage.xaml
@@ -156,14 +156,12 @@
 
 				<Button
 					FontAttributes="Bold"
-					FontSize="12"
 					Text="Last 10 Transactions"
 					Command="{Binding NavigateToTransactionsPageCommand}"/>
 
 				<Button
 					Command="{Binding NavigateToCertifierPageCommand}"
 					FontAttributes="Bold"
-					FontSize="12"
 					Text="Community Operations" />
 			</StackLayout>
 			<StackLayout IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" Grid.Row="2" Grid.ColumnSpan="3" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" Spacing="15" Padding="20">

--- a/src/BolWallet/Views/MainWithAccountPage.xaml.cs
+++ b/src/BolWallet/Views/MainWithAccountPage.xaml.cs
@@ -32,4 +32,9 @@ public partial class MainWithAccountPage : ContentPage
 			Toast.Make("Copied to Clipboard").Show();
 		}
 	}
+    
+    protected override bool OnBackButtonPressed()
+    {
+        return false;
+    }
 }

--- a/src/BolWallet/Views/MoveClaimPage.xaml
+++ b/src/BolWallet/Views/MoveClaimPage.xaml
@@ -184,7 +184,6 @@
                 Grid.Row="8"
                 Command="{Binding MoveClaimCommand}"
                 FontAttributes="Bold"
-                FontSize="8"
                 HorizontalOptions="FillAndExpand"
                 Text="Transfer" />
 

--- a/src/BolWallet/Views/RetrieveBolPage.xaml
+++ b/src/BolWallet/Views/RetrieveBolPage.xaml
@@ -26,7 +26,6 @@
                 Grid.Row="1"
                 Clicked="OnClickCopyCodename"
                 FontAttributes="Bold"
-                FontSize="8"
                 HorizontalOptions="FillAndExpand"
                 Text="{Binding CodenameText}" />
 
@@ -34,7 +33,6 @@
                 Grid.Row="2"
                 Clicked="OnClickCopyAddress"
                 FontAttributes="Bold"
-                FontSize="8"
                 HorizontalOptions="FillAndExpand"
                 Text="{Binding CommAddressText}" />
         </Grid>

--- a/src/BolWallet/Views/SendBolPage.xaml
+++ b/src/BolWallet/Views/SendBolPage.xaml
@@ -223,7 +223,6 @@
                 Grid.Row="8"
                 Command="{Binding SendBolCommand}"
                 FontAttributes="Bold"
-                FontSize="8"
                 HorizontalOptions="FillAndExpand"
                 Text="Send" />
 

--- a/src/BolWallet/Views/UserPage.xaml
+++ b/src/BolWallet/Views/UserPage.xaml
@@ -57,7 +57,6 @@
                 Command="{Binding NavigateToTransaction1PageCommand}"
                 FontAttributes="Bold"
                 HorizontalOptions="Center"
-                FontSize="8"
                 Text="{Binding TransactionButton1Label}" />
 
             <Button
@@ -66,7 +65,6 @@
                 Command="{Binding NavigateToTransaction2PageCommand}"
                 FontAttributes="Bold"
                 HorizontalOptions="Center"
-                FontSize="8"
                 Text="{Binding TransactionButton2Label}" />
             
             <Entry x:Name="eEntry" Grid.Column="0" Grid.Row="4"

--- a/src/scripts/android/publish-android-ad-hoc.sh
+++ b/src/scripts/android/publish-android-ad-hoc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net8.0-android -c Release -p:AndroidKeyStore=true -p:AndroidSigningKeyStore=$1 -p:AndroidSigningKeyAlias=bolwallet -p:AndroidSigningKeyPass=file:$2 -p:AndroidSigningStorePass=file:$2 ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net9.0-android -c Release -p:AndroidKeyStore=true -p:AndroidSigningKeyStore=$1 -p:AndroidSigningKeyAlias=bolwallet -p:AndroidSigningKeyPass=file:$2 -p:AndroidSigningStorePass=file:$2 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/publish-ios-ad-hoc.sh
+++ b/src/scripts/ios/publish-ios-ad-hoc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net8.0-ios -c Release -p:ArchiveOnBuild=true ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net9.0-ios -c Release -p:ArchiveOnBuild=true ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/publish-ios-app-store.sh
+++ b/src/scripts/ios/publish-ios-app-store.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net8.0-ios -p:ApplicationVersion=$1 -p:ApplicationDisplayVersion=$2 ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net9.0-ios -p:ApplicationVersion=$1 -p:ApplicationDisplayVersion=$2 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/run-iPhone.sh
+++ b/src/scripts/ios/run-iPhone.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -t:Run -f net8.0-ios -c Release -p:RuntimeIdentifier=ios-arm64 -p:_DeviceName=$1 ./../../BolWallet/BolWallet.csproj
+dotnet build -t:Run -f net9.0-ios -c Release -p:RuntimeIdentifier=ios-arm64 -p:_DeviceName=$1 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst-arm64.sh
+++ b/src/scripts/macos/publish-maccatalyst-arm64.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net8.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-arm64 ./../../BolWallet.csproj
+dotnet build -f net9.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-arm64 ./../../BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst-x64.sh
+++ b/src/scripts/macos/publish-maccatalyst-x64.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net8.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-x64 ./../../BolWallet.csproj
+dotnet build -f net9.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-x64 ./../../BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst.sh
+++ b/src/scripts/macos/publish-maccatalyst.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net8.0-maccatalyst -c Release ./../../BolWallet/BolWallet.csproj
+dotnet build -f net9.0-maccatalyst -c Release ./../../BolWallet/BolWallet.csproj


### PR DESCRIPTION
Changes:

- Upgrades to `net9.0`.
- Upgrades to MAUI `9.0.0`.
- The password popup when importing wallet is deprecated in favor of the native prompt which now supports a `Password` keyboard type.
  - The password popup is not deleted but is not used anymore. Regardless, a bug was fixed where the popup was closed when losing focus in case the popup gets utilized in the future.
- Deprecates use of MainPage as per the new guidelines.
- The left-side menu now shows `BOL Wallet` instead of `Bol Menu` at the top.
  - The app version is now shown as a caption under it.
- Several XAML buttons now have their font size removed to be easier to read using a default font size which scales better with the button size.
- Attempts to fix a rare bug on Android where the app crashed when navigating from the `PreloadViewModel` to one of the main viewmodels.
  - As a result the root is not changed during this navigation anymore.
  - Both main pages have their back button disabled and back button press on Android now does nothing.
- Removes permanent permission use of `READ_MEDIA_IMAGES` to comply with Google's policies.
  - The user is still able to pick photos since the photo library is shown allowing them to select photos.
- Updates to `akavache` version `10.1.6`.
- Build scripts were updated to target `net9`.