### PR TITLE
Fix windows log saving

### DIFF
--- a/src/BolWallet/App.xaml.cs
+++ b/src/BolWallet/App.xaml.cs
@@ -4,7 +4,7 @@ using CommunityToolkit.Mvvm.Messaging;
 
 namespace BolWallet;
 
-public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
+public partial class App : Application, IRecipient<TargetNetworkChangedMessage>, IRecipient<DisplayErrorMessage>
 {
     private readonly INetworkPreferences _networkPreferences;
     private ILogExtractor _logExtractor = null!;
@@ -14,7 +14,7 @@ public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
         _networkPreferences = networkPreferences;
         InitializeComponent();
 
-        messenger.Register(this);
+        messenger.RegisterAll(this);
 		UserAppTheme = AppTheme.Light;
 
 #if WINDOWS
@@ -85,4 +85,13 @@ public partial class App : Application, IRecipient<TargetNetworkChangedMessage>
     private string CreateWindowTitle() => _networkPreferences.IsMainNet
         ? Constants.AppName
         : $"{Constants.AppName} ({_networkPreferences.Name})";
+
+    void IRecipient<DisplayErrorMessage>.Receive(DisplayErrorMessage message)
+    {
+        var text = message.Exception is null
+            ? message.Message
+            : $"{message.Message}{Environment.NewLine}{Environment.NewLine}{message.Exception.ToString()}";
+
+        Current.Windows[0].Page.DisplayAlert("Error", text, "OK");
+    }
 }

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -30,7 +30,8 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>	  <DefaultLanguage>en-US</DefaultLanguage>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -30,9 +30,9 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>	<DefaultLanguage>en-US</DefaultLanguage>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>	  <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
@@ -78,8 +78,13 @@
     <CodesignEntitlements>Platforms\MacCatalyst\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(Configuration)' == 'Release'">
     <WarningsAsErrors />
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+  </PropertyGroup>
+      
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
+    <RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BolWallet/Extensions/LoggingExtensions.cs
+++ b/src/BolWallet/Extensions/LoggingExtensions.cs
@@ -35,7 +35,6 @@ public static class LoggingExtensions
                 outputTemplate,
                 filePath,
                 encoding: Encoding.UTF8,
-                flushToDiskInterval: TimeSpan.FromSeconds(1),
                 fileSizeLimitBytes: MaxFileSizeLimitBytes,
                 rollingInterval: RollingInterval.Day,
                 rollOnFileSizeLimit: true)

--- a/src/BolWallet/Extensions/LoggingExtensions.cs
+++ b/src/BolWallet/Extensions/LoggingExtensions.cs
@@ -37,7 +37,9 @@ public static class LoggingExtensions
                 encoding: Encoding.UTF8,
                 fileSizeLimitBytes: MaxFileSizeLimitBytes,
                 rollingInterval: RollingInterval.Day,
-                rollOnFileSizeLimit: true)
+                rollOnFileSizeLimit: true,
+                retainedFileCountLimit: 15,
+                retainedFileTimeLimit: TimeSpan.FromDays(15))
             .WriteTo.Console(outputTemplate)
             .CreateLogger();
 

--- a/src/BolWallet/Extensions/LoggingExtensions.cs
+++ b/src/BolWallet/Extensions/LoggingExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class LoggingExtensions
 {
-    private const long MaxFileSizeLimitBytes = 1048576L;
+    private const long MaxFileSizeLimitBytes = 10_000_000;
 
     public static IServiceCollection ConfigureSerilog(this IServiceCollection services)
     {

--- a/src/BolWallet/Extensions/LoggingExtensions.cs
+++ b/src/BolWallet/Extensions/LoggingExtensions.cs
@@ -35,6 +35,7 @@ public static class LoggingExtensions
                 outputTemplate,
                 filePath,
                 encoding: Encoding.UTF8,
+                shared: true,
                 fileSizeLimitBytes: MaxFileSizeLimitBytes,
                 rollingInterval: RollingInterval.Day,
                 rollOnFileSizeLimit: true,

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -69,6 +69,7 @@ builder.ConfigureMauiHandlers(handlers =>
         RegisterPermissionServices(services);
 
         services.AddSingleton(MediaPicker.Default);
+        builder.Services.AddSingleton<IFileSystem>(FileSystem.Current);
         builder.Services.AddSingleton<IFileSaver>(FileSaver.Default);
 
         services.AddSingleton<IDeviceDisplay>(DeviceDisplay.Current);

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -12,6 +12,7 @@ using CommunityToolkit.Maui.Storage;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.LifecycleEvents;
 using MudBlazor.Services;
 using Plugin.Maui.Audio;
 using Country = BolWallet.Models.Country;
@@ -28,6 +29,18 @@ public static class MauiProgram
         builder
             .UseMauiApp<App>()
             .UseMauiCommunityToolkit()
+            .ConfigureLifecycleEvents(AppLifeCycle =>
+            {
+#if WINDOWS
+                    AppLifeCycle.AddWindows(windows =>
+                    {
+                        windows.OnClosed((app, e) =>
+                        {
+                            Environment.Exit(0);
+                        });
+                    });
+#endif
+            })
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -50,6 +50,9 @@ public static class MauiProgram
 
         builder.Services.AddSingleton<IAppVersion, AppVersion>();
         builder.Services.AddMauiBlazorWebView();
+#if DEBUG
+        builder.Services.AddBlazorWebViewDeveloperTools();
+#endif
 
         builder.Services.AddMudServices();
 

--- a/src/BolWallet/Models/Messages/DisplayErrorMessage.cs
+++ b/src/BolWallet/Models/Messages/DisplayErrorMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace BolWallet.Models.Messages;
+
+internal record DisplayErrorMessage(string Message, Exception Exception = null);

--- a/src/BolWallet/Platforms/Windows/Package.appxmanifest
+++ b/src/BolWallet/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="3.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="3.0.0.1" />
 
   <mp:PhoneIdentity PhoneProductId="91ADD539-7E17-4B6C-9E6D-310A654419CD" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/BolWallet/Services/LogExtractor.cs
+++ b/src/BolWallet/Services/LogExtractor.cs
@@ -70,14 +70,19 @@ public class LogExtractor : ILogExtractor, IRecipient<SaveLogfileMessage>
 
             using var fileStream = File.OpenRead(zipFilePath);
             var result = await _fileSaver.SaveAsync(zipFileName, fileStream, token);
-
             if (result.IsSuccessful)
             {
                 await Toast.Make($"File '{zipFileName}' saved successfully!").Show(token);
                 return;
             }
 
-            _messenger.Send(new DisplayErrorMessage("An error occurred while saving the logfile", result.Exception));
+            if (result.FilePath == null)
+            {
+                _logger.LogInformation("Log extraction cancelled by user.");
+                return;
+            }
+
+            _messenger.Send(new DisplayErrorMessage("An error occurred while saving the logfile.", result.Exception));
         }
         catch (Exception ex)
         {

--- a/src/BolWallet/Services/LogExtractor.cs
+++ b/src/BolWallet/Services/LogExtractor.cs
@@ -3,46 +3,106 @@ using BolWallet.Models.Messages;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Storage;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
 
 namespace BolWallet.Services;
 
 public class LogExtractor : ILogExtractor, IRecipient<SaveLogfileMessage>
 {
+    private readonly IMessenger _messenger;
     private readonly TimeProvider _timeProvider;
+    private readonly IFileSystem _fileSystem;
     private readonly IFileSaver _fileSaver;
+    private readonly ILogger _logger;
 
     public LogExtractor(
         IMessenger messenger,
         TimeProvider timeProvider,
-        IFileSaver fileSaver)
+        IFileSystem fileSystem,
+        IFileSaver fileSaver,
+        ILogger<LogExtractor> logger)
     {
         messenger.Register<SaveLogfileMessage>(this);
         
+        _messenger = messenger;
         _timeProvider = timeProvider;
+        _fileSystem = fileSystem;
         _fileSaver = fileSaver;
+        _logger = logger;
     }
 
     public async Task ExtractLog(CancellationToken token = default)
     {
-        var zipFileName = $"BolWalletLogs_{_timeProvider.GetUtcNow():yyyyMMddHHmmss}.zip";
-        var logDirectory = Path.Combine(FileSystem.AppDataDirectory,
-            "Logs",
-            AppInfo.Current.Name,
-            AppInfo.Current.VersionString);
+        var now = _timeProvider.GetUtcNow();
 
-        using var stream = new MemoryStream();
-        ZipFile.CreateFromDirectory(logDirectory, stream);
-            
-        var result = await _fileSaver.SaveAsync(zipFileName, stream, token);
+        var zipFileName = $"BolWalletLogs_{now:yyyyMMddHHmmss}.zip";
+        var zipFilePath = Path.Combine(_fileSystem.CacheDirectory, zipFileName);
+        DeleteFileIfExists(zipFilePath);
 
-        if (result.IsSuccessful)
+        var tempLog = $"BolWalletLogs_Temp_{now:yyyyMMddHHmmss}.log";
+        var tempLogPath = Path.Combine(_fileSystem.CacheDirectory, tempLog);
+        DeleteFileIfExists(tempLogPath);
+
+        try
         {
-            await Toast.Make($"File '{zipFileName}' saved successfully!").Show(token);
+            var logDirectory = Path.Combine(FileSystem.AppDataDirectory,
+                "Logs",
+                AppInfo.Current.Name,
+                AppInfo.Current.VersionString);
+
+            using var stream = new MemoryStream();
+
+            using (var zip = ZipFile.Open(zipFilePath, ZipArchiveMode.Create))
+            {
+                foreach (var file in Directory.GetFiles(logDirectory))
+                {
+                    try
+                    {
+                        zip.CreateEntryFromFile(file, Path.GetFileName(file));
+                    }
+                    catch
+                    {
+                        File.Copy(file, tempLogPath);
+                        zip.CreateEntryFromFile(tempLogPath, Path.GetFileName(file));
+                    }
+                }
+            }
+
+            using var fileStream = File.OpenRead(zipFilePath);
+            var result = await _fileSaver.SaveAsync(zipFileName, fileStream, token);
+
+            if (result.IsSuccessful)
+            {
+                await Toast.Make($"File '{zipFileName}' saved successfully!").Show(token);
+                return;
+            }
+
+            _messenger.Send(new DisplayErrorMessage("An error occurred while saving the logfile", result.Exception));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error extracting logs...");
+            _messenger.Send(new DisplayErrorMessage("An error occurred while saving the logfile.", ex));
+        }
+        finally
+        {
+            DeleteFileIfExists(zipFilePath);
+            DeleteFileIfExists(tempLogPath);
         }
     }
 
     public void Receive(SaveLogfileMessage message)
     {
+        _logger.LogInformation("Log extraction requested...");
+
         MainThread.BeginInvokeOnMainThread(() => _ = ExtractLog());
+    }
+
+    private static void DeleteFileIfExists(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
     }
 }

--- a/src/scripts/windows/publish-side-load.ps1
+++ b/src/scripts/windows/publish-side-load.ps1
@@ -1,0 +1,6 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)][string]$t
+)
+
+dotnet publish .\..\..\BolWallet\BolWallet.csproj -f net9.0-windows10.0.19041.0 -c Release -p:RuntimeIdentifierOverride=win10-x64 -p:PackageCertificateThumbprint=$t

--- a/src/scripts/windows/publish-side-load.ps1
+++ b/src/scripts/windows/publish-side-load.ps1
@@ -3,4 +3,4 @@ param (
     [Parameter(Mandatory=$true)][string]$t
 )
 
-dotnet publish .\..\..\BolWallet\BolWallet.csproj -f net9.0-windows10.0.19041.0 -c Release -p:RuntimeIdentifierOverride=win10-x64 -p:PackageCertificateThumbprint=$t
+dotnet publish .\..\..\BolWallet\BolWallet.csproj -f net9.0-windows10.0.19041.0 -c Release --self-contained -p:RuntimeIdentifierOverride=win10-x64 -p:PackageCertificateThumbprint=$t


### PR DESCRIPTION
Fixes saving logfiles on Windows.

Other changes:
- A new `DisplayErrorMessage` is introduced to be used with `IMessenger`. The App instance receives such messages and displays an alert.
- Log files max limit is increased to 10 MB.
- 15 log files are retained at maximum.
- Log files are retained for 15 days maximum.
- Logger doesn't use flush interval.
- [Windows] When app exits a proper environment exit happens.
- A new build script is added for Windows side-load builds. A certificate thumbprint argument must be provided, for example:
```
.\publish-side-load.ps1 -t <my-dev-cert-thumbprint>
```