### PR TITLE
[3.3.1 regression] Fix app startup crash, upgrade to net10

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('macos'))">$(TargetFrameworks);net9.0-maccatalyst;net9.0-ios</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('macos'))">$(TargetFrameworks);net10.0-maccatalyst;net10.0-ios</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>BolWallet</RootNamespace>
     <UseMaui>true</UseMaui>
-    <MauiVersion>9.0.120</MauiVersion>
+    <MauiVersion>10.0.51</MauiVersion>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
 
@@ -34,11 +34,11 @@
     <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
     <WarningsAsErrors />
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
@@ -46,28 +46,28 @@
     <CodesignProvision>Automatic</CodesignProvision>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
     <WarningsAsErrors />
     <AndroidLinkTool>r8</AndroidLinkTool>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
     <WarningsAsErrors />
-    <ArchiveOnBuild>true</ArchiveOnBuild>
+    <ArchiveOnBuild>false</ArchiveOnBuild>
     <CodesignProvision>Automatic</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
     <WarningsAsErrors />
     <MtouchLink>SdkOnly</MtouchLink> 
     <CreatePackage>true</CreatePackage>
@@ -222,11 +222,12 @@
   <ItemGroup>
     <PackageReference Include="Akavache.Sqlite3" Version="11.5.1" />
     <PackageReference Include="Akavache.NewtonsoftJson" Version="11.5.1" />
-    <PackageReference Include="Blazing.Mvvm" Version="1.4.0" />
+    <PackageReference Include="Blazing.Mvvm" Version="3.2.1" />
     <PackageReference Include="BolChain.Core" Version="1.1.4" />
-    <PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
+
+    <PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 <!--    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />-->
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
@@ -234,13 +235,13 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="Neo.VM" Version="2.4.3.1" />
     <PackageReference Include="MudBlazor" Version="6.19.1" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SimpleResults" Version="2.3.2" />
   </ItemGroup>
 
@@ -284,6 +285,7 @@
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
     <BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+
   </ItemGroup>
-  
+
 </Project>

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -61,9 +61,9 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
     <WarningsAsErrors />
-    <ArchiveOnBuild>false</ArchiveOnBuild>
+    <ArchiveOnBuild>true</ArchiveOnBuild>
     <CodesignProvision>Automatic</CodesignProvision>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
 

--- a/src/BolWallet/BolWallet.csproj
+++ b/src/BolWallet/BolWallet.csproj
@@ -227,6 +227,7 @@
 
     <PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 <!--    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />-->

--- a/src/BolWallet/MauiProgram.cs
+++ b/src/BolWallet/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Blazing.Mvvm;
 using Akavache.NewtonsoftJson;
 using Akavache.Sqlite3;
 using Splat.Builder;
@@ -60,6 +61,7 @@ public static class MauiProgram
 #endif
 
         builder.Services.AddMudServices();
+        builder.Services.AddMvvm();
 
 #if DEBUG
         builder.Services.AddBlazorWebViewDeveloperTools();

--- a/src/BolWallet/Models/BolWalletAppConfig.cs
+++ b/src/BolWallet/Models/BolWalletAppConfig.cs
@@ -5,4 +5,4 @@ public readonly record struct BolWalletAppConfig(
     string BolIdentityEndpoint,
     string BolExplorerEndpoint,
     string BolCertifierEndpoint,
-    string Contract);
+    string Contract = "");

--- a/src/BolWallet/Platforms/Android/AndroidManifest.xml
+++ b/src/BolWallet/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.bol.bolwallet" android:versionCode="14" android:versionName="3.3.1 (2026.0328.1800)">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.bol.bolwallet" android:versionCode="16" android:versionName="3.4.0 (2026.0329.0100)">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true" android:label="BoL Wallet"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/src/BolWallet/Platforms/MacCatalyst/Info.plist
+++ b/src/BolWallet/Platforms/MacCatalyst/Info.plist
@@ -31,9 +31,9 @@
 		<string>processing</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026.0328.1800</string>
+	<string>2026.0329.0100</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.1</string>
+	<string>3.4.0</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>NSHumanReadableCopyright</key>

--- a/src/BolWallet/Platforms/Windows/Package.appxmanifest
+++ b/src/BolWallet/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="3.3.1.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="3.4.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="91ADD539-7E17-4B6C-9E6D-310A654419CD" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/BolWallet/Platforms/iOS/Info.plist
+++ b/src/BolWallet/Platforms/iOS/Info.plist
@@ -35,9 +35,9 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>The app can use the photo library to select photos from your library and use them when creating a new wallet.</string>
 	<key>CFBundleVersion</key>
-	<string>2026.0328.1800</string>
+	<string>2026.0329.0100</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.1</string>
+	<string>3.4.0</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>NSHumanReadableCopyright</key>

--- a/src/BolWallet/Properties/PublishProfiles/MSIX-win-arm64.pubxml
+++ b/src/BolWallet/Properties/PublishProfiles/MSIX-win-arm64.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishDir>bin\Release\net10.0-windows10.0.19041.0\win-x64\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <Platform>Any CPU</Platform>
+    <Configuration>Release</Configuration>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <SelfContained>True</SelfContained>
+    <PublishAppxPackage>true</PublishAppxPackage>
+    <AppxPackageDir>bin\Release\net10.0-windows10.0.19041.0\win-arm64\publish\AppPackages\</AppxPackageDir>
+  </PropertyGroup>
+</Project>

--- a/src/BolWallet/Properties/PublishProfiles/MSIX-win-x64.pubxml
+++ b/src/BolWallet/Properties/PublishProfiles/MSIX-win-x64.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishDir>bin\Release\net10.0-windows10.0.19041.0\win-x64\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Platform>Any CPU</Platform>
+    <Configuration>Release</Configuration>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <SelfContained>True</SelfContained>
+    <PublishAppxPackage>true</PublishAppxPackage>
+    <AppxPackageDir>bin\Release\net10.0-windows10.0.19041.0\win-x64\publish\AppPackages\</AppxPackageDir>
+  </PropertyGroup>
+</Project>

--- a/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
+++ b/src/BolWallet/ViewModels/MainWithAccountViewModel.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Mvvm.Messaging;
 
 namespace BolWallet.ViewModels;
-public partial class MainWithAccountViewModel : BaseViewModel, IDisposable
+public partial class MainWithAccountViewModel : BaseViewModel
 {
     private readonly ISecureRepository _secureRepository;
     private readonly IBolService _bolService;
@@ -280,13 +280,19 @@ public partial class MainWithAccountViewModel : BaseViewModel, IDisposable
         await _closeWalletService.CloseWallet();
     }
 
-    public void Dispose()
+    protected override void Dispose(bool disposing)
     {
-        if (_cts is { IsCancellationRequested: false })
+        if (disposing)
         {
-            _cts.Cancel();
+            if (_cts is { IsCancellationRequested: false })
+            {
+                _cts.Cancel();
+            }
+        
+            _cts.Dispose();
         }
         
-        _cts.Dispose();
+        // Always call base to ensure command subscriptions are cleaned up
+        base.Dispose(disposing);
     }
 }

--- a/src/BolWallet/ViewModels/PasswordPopup.cs
+++ b/src/BolWallet/ViewModels/PasswordPopup.cs
@@ -25,9 +25,9 @@ public sealed class PasswordPopup : Popup
             ClearButtonVisibility = ClearButtonVisibility.WhileEditing
         };
         
-        passwordEntry.Completed += (sender, e) =>
+        passwordEntry.Completed += async (sender, e) =>
         {
-            Close();
+            await CloseAsync();
             TaskCompletionSource.SetResult(passwordEntry.Text);
         };
 
@@ -43,9 +43,9 @@ public sealed class PasswordPopup : Popup
             IsVisible = false
         };
 
-        submitButton.Clicked += (sender, e) =>
+        submitButton.Clicked += async (sender, e) =>
         {
-            Close();
+            await CloseAsync();
             TaskCompletionSource.SetResult(passwordEntry.Text);
         };
 
@@ -60,9 +60,9 @@ public sealed class PasswordPopup : Popup
             HorizontalOptions = LayoutOptions.Fill
         };
 
-        cancelButton.Clicked += (sender, e) =>
+        cancelButton.Clicked += async (sender, e) =>
         {
-            Close();
+            await CloseAsync();
             TaskCompletionSource.SetResult(null);
         };
 

--- a/src/scripts/android/publish-android-ad-hoc.sh
+++ b/src/scripts/android/publish-android-ad-hoc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net9.0-android -c Release -p:AndroidKeyStore=true -p:AndroidSigningKeyStore=$1 -p:AndroidSigningKeyAlias=bolwallet -p:AndroidSigningKeyPass=file:$2 -p:AndroidSigningStorePass=file:$2 ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net10.0-android -c Release -p:AndroidKeyStore=true -p:AndroidSigningKeyStore=$1 -p:AndroidSigningKeyAlias=bolwallet -p:AndroidSigningKeyPass=file:$2 -p:AndroidSigningStorePass=file:$2 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/publish-ios-ad-hoc.sh
+++ b/src/scripts/ios/publish-ios-ad-hoc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net9.0-ios -c Release -p:ArchiveOnBuild=true ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net10.0-ios -c Release -p:ArchiveOnBuild=true ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/publish-ios-app-store.sh
+++ b/src/scripts/ios/publish-ios-app-store.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet publish -f net9.0-ios -p:ApplicationVersion=$1 -p:ApplicationDisplayVersion=$2 ./../../BolWallet/BolWallet.csproj
+dotnet publish -f net10.0-ios -p:ApplicationVersion=$1 -p:ApplicationDisplayVersion=$2 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/ios/run-iPhone.sh
+++ b/src/scripts/ios/run-iPhone.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -t:Run -f net9.0-ios -c Release -p:RuntimeIdentifier=ios-arm64 -p:_DeviceName=$1 ./../../BolWallet/BolWallet.csproj
+dotnet build -t:Run -f net10.0-ios -c Release -p:RuntimeIdentifier=ios-arm64 -p:_DeviceName=$1 ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst-arm64.sh
+++ b/src/scripts/macos/publish-maccatalyst-arm64.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net9.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-arm64 ./../../BolWallet.csproj
+dotnet build -f net10.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-arm64 ./../../BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst-x64.sh
+++ b/src/scripts/macos/publish-maccatalyst-x64.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net9.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-x64 ./../../BolWallet.csproj
+dotnet build -f net10.0-maccatalyst -c Release -p:RuntimeIdentifier=maccatalyst-x64 ./../../BolWallet.csproj

--- a/src/scripts/macos/publish-maccatalyst.sh
+++ b/src/scripts/macos/publish-maccatalyst.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet build -f net9.0-maccatalyst -c Release ./../../BolWallet/BolWallet.csproj
+dotnet build -f net10.0-maccatalyst -c Release ./../../BolWallet/BolWallet.csproj

--- a/src/scripts/windows/publish-side-load.ps1
+++ b/src/scripts/windows/publish-side-load.ps1
@@ -3,4 +3,4 @@ param (
     [Parameter(Mandatory=$true)][string]$t
 )
 
-dotnet publish .\..\..\BolWallet\BolWallet.csproj -f net9.0-windows10.0.19041.0 -c Release --self-contained -p:RuntimeIdentifierOverride=win10-x64 -p:PackageCertificateThumbprint=$t
+dotnet publish .\..\..\BolWallet\BolWallet.csproj -f net10.0-windows10.0.19041.0 -c Release --self-contained -p:RuntimeIdentifierOverride=win10-x64 -p:PackageCertificateThumbprint=$t


### PR DESCRIPTION
Fixes an issue where `BolWalletAppConfig` binding from appsettings failed in runtime for the `3.3.1` release build.

`BolWalletAppConfig.Contract` was initialized to a default, thus overcoming this strict runtime binding because of the empty string value used in `appsettings.json`.

Also, `net10` sdk tooling was used to build the `3.3.1` version which was still targetting `net9` and this apparently caused trimming issues.

The app is now upgraded to .NET 10 and builds and runs properly in all platforms without changing any of the project's trimming configuration. Several dependencies were also upgraded to bring in their latest versions with a .NET 10 target.

Last but not least, `Bolchain.Core` depends on `Microsoft.Extensions.Caching.Memory 8.0.0` which has a known vulnerability so until it upgrades, thus an explicit reference to its `10.0.0` version was added to overcome the issue until `Bolchain.Core` upgrades its references.